### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name"          : "OpenCV",
+  "license"       : "MIT",
   "version"       : "0.0.5",
   "perl"          : "6.c",
   "description"   : "OpenCV Bindings using NativeCall",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license